### PR TITLE
Bump security string to 2018-06-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -131,7 +131,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2018-05-05
+    PLATFORM_SECURITY_PATCH := 2018-06-05
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
Implented patches:
-----------------------------------------------------
CVE-2018-9338	A-71361168	EoP	High
CVE-2018-9340	A-71360999	ID      High
CVE-2018-9341	A-74016277	RCE	Critical
CVE-2018-5146	A-77284393*	RCE	Critical
CVE-2018-9345	A-77238250	ID	High
CVE-2018-9346	A-77238762	ID	High
CVE-2018-9347	A-68664359	DoS	High
CVE-2018-9348	A-68953854	DoS	High
CVE-2018-9355	A-74016921	RCE	Critical
CVE-2018-9356	A-74950468	RCE	Critical
CVE-2018-9357	A-74947856	RCE	Critical
CVE-2018-9358	A-73172115	ID	High
CVE-2018-9359	A-74196706	ID	High
CVE-2018-9360	A-74201143	ID	High
CVE-2018-9361	A-74202041	ID	High
CVE-2018-9362	A-72298611	DoS	High
CVE-2018-9375	A-75298708	EoP	Moderate
CVE-2018-9378	A-73126106	ID	Moderate
CVE-2018-9379	A-63766886[2]	ID	Moderate
CVE-2018-9349	A-72510002	ID	Moderate
CVE-2018-9350	A-73552574	ID	Moderate
CVE-2018-9351	A-73625898	ID	Moderate
CVE-2018-9352	A-73965867[2]	ID	Moderate
CVE-2018-9353	A-73965890	ID	Moderate
CVE-2018-9354	A-74067957	NSI	NSI
CVE-2018-9380	A-75298652	EoP	Moderate

Postponed:
-----------------------------------------------------
CVE-2018-9374	A-72710897	EoP	Moderate

Not implemented / not relevant:
-----------------------------------------------------
CVE-2018-9339	A-71508348	High	   8.0, 8.1
CVE-2017-13227	A-69981710	High	   8.0, 8.1
CVE-2017-13230	A-65483665	Critical   6.0
CVE-2018-9344	A-73172817	High	   8.1
CVE-2018-9377	A-64752751*	Moderate   6.0, 6.0.1
CVE-2018-9382	A-35765136*	Moderate   not found

Change-Id: I0284581d30c76df838b05a312c1223f5dfcf0ecf